### PR TITLE
Add support for unicode when creating uuid

### DIFF
--- a/slingshot/app.py
+++ b/slingshot/app.py
@@ -34,8 +34,15 @@ def submit(archive, url):
 
 
 def make_uuid(value, namespace):
-    ns = uuid.uuid5(uuid.NAMESPACE_DNS, namespace)
-    uid = uuid.uuid5(ns, value)
+    try:
+        ns = uuid.uuid5(uuid.NAMESPACE_DNS, namespace)
+        uid = uuid.uuid5(ns, value)
+    except UnicodeDecodeError:
+        # Python 2 requires a byte string for the second argument.
+        # Python 3 requires a unicode string for the second argument.
+        value, namespace = [_bytes(s) for s in (value, namespace)]
+        ns = uuid.uuid5(uuid.NAMESPACE_DNS, namespace)
+        uid = uuid.uuid5(ns, value)
     return str(uid)
 
 
@@ -61,3 +68,7 @@ def temp_archive(data, name):
 def sub_dirs(directory):
     return [d for d in os.listdir(directory)
             if os.path.isdir(os.path.join(directory, d))]
+
+
+def _bytes(value):
+    return bytearray(value, 'utf-8')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -53,6 +53,11 @@ def test_make_uuid_creates_uuid_string():
         'aabfaa4e-15a2-51b5-a684-46c530cb0263'
 
 
+def test_make_uuid_works_with_unicode_values():
+    assert make_uuid('grayscale', u'arrowsmith.mit.edu') == \
+        'aabfaa4e-15a2-51b5-a684-46c530cb0263'
+
+
 def test_sub_dirs_returns_list_of_sub_directories():
     d = tempfile.mkdtemp()
     os.mkdir(os.path.join(d, 'foo'))


### PR DESCRIPTION
The uuid module differs in support for unicode between python 2 and
3. This should correctly handle either unicode or byte strings.