### PR TITLE
Add upload to S3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,10 @@
 bagit==1.5.4
+boto3==1.3.1
+botocore==1.4.36
 click==6.3
+docutils==0.12
+futures==3.0.5
+jmespath==0.9.0
+python-dateutil==2.5.3
 requests==2.9.1
-wheel==0.26.0
+six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'bagit',
+        'boto3',
         'click',
         'requests',
     ],

--- a/slingshot/__init__.py
+++ b/slingshot/__init__.py
@@ -3,8 +3,8 @@
 Slingshot
 """
 
-from .app import (make_uuid, submit, temp_archive, prep_bag, make_bag_dir,
-                  uploadable,)
+from .app import (make_uuid, temp_archive, make_bag_dir, write_fgdc, Kepler,
+                  flatten_zip)
 
 
 __version__ = '0.1.0'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import shutil
 import tempfile
 
 import pytest
+import requests_mock
 
 
 @pytest.yield_fixture(scope="session", autouse=True)
@@ -44,6 +45,20 @@ def layers_dir(shapefile):
     d = tempfile.mkdtemp()
     shutil.copy2(shapefile, d)
     return d
+
+
+@pytest.yield_fixture
+def kepler():
+    with requests_mock.Mocker() as m:
+        m.register_uri('GET', '/failed/47458e22-8e50-5b43-ac80-b662a1077af1',
+                       json={'status': 'FAILED'})
+        m.register_uri('GET', '/404/47458e22-8e50-5b43-ac80-b662a1077af1',
+                       status_code=404)
+        m.register_uri('GET',
+                       '/completed/47458e22-8e50-5b43-ac80-b662a1077af1',
+                       json={'status': 'COMPLETED'})
+        m.register_uri('PUT', requests_mock.ANY)
+        yield m
 
 
 def _data_file(name):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,69 +15,85 @@ def runner():
     return CliRunner()
 
 
-def test_run_submits_job(runner, layers_dir, kepler):
+def test_run_uploads_to_s3(runner, layers_dir, kepler, s3):
+    store = tempfile.mkdtemp()
+    runner.invoke(main, ['run', layers_dir, store, 'mock://example.com/404',
+                         '--s3-key', 'foo', '--s3-secret', 'bar'])
+    assert s3.head_object(Bucket='kepler',
+                          Key='47458e22-8e50-5b43-ac80-b662a1077af1')
+
+
+def test_run_submits_job(runner, layers_dir, kepler, s3):
     store = tempfile.mkdtemp()
     res = runner.invoke(main, ['run', layers_dir, store,
-                               'mock://example.com/404'])
+                               'mock://example.com/404', '--s3-key', 'foo',
+                               '--s3-secret', 'bar'])
     assert res.exit_code == 0
     assert kepler.request_history[0].method == 'GET'
     assert kepler.request_history[1].method == 'PUT'
 
 
-def test_run_leaves_bag_on_success(runner, layers_dir, kepler):
+def test_run_leaves_bag_on_success(runner, layers_dir, kepler, s3):
     store = tempfile.mkdtemp()
-    runner.invoke(main, ['run', layers_dir, store, 'mock://example.com/404'])
+    runner.invoke(main, ['run', layers_dir, store, 'mock://example.com/404',
+                         '--s3-key', 'foo', '--s3-secret', 'bar'])
     bag = os.path.join(store, 'SDE_DATA_BD_A8GNS_2003/data')
     assert 'SDE_DATA_BD_A8GNS_2003.zip' in os.listdir(bag)
     assert 'SDE_DATA_BD_A8GNS_2003.xml' in os.listdir(bag)
 
 
-def test_run_removes_bag_on_failure(runner, layers_dir, kepler):
-    kepler.register_uri('PUT', requests_mock.ANY, status_code=500)
+def test_run_removes_bag_on_failure(runner, layers_dir, kepler, s3):
+    kepler.put(requests_mock.ANY, status_code=500)
     store = tempfile.mkdtemp()
     res = runner.invoke(main, ['run', layers_dir, store,
-                               'mock://example.com/404'])
+                               'mock://example.com/404', '--s3-key', 'foo',
+                               '--s3-secret', 'bar'])
     assert res.exit_code == 0
     assert not os.path.isdir(os.path.join(store, 'SDE_DATA_BD_A8GNS_2003'))
 
 
-def test_run_uses_supplied_namespace(runner, layers_dir, kepler):
+def test_run_uses_supplied_namespace(runner, layers_dir, kepler, s3):
     kepler.get('/90ebb45f-ad77-5c30-ab90-1b7e389f3398', status_code=404)
     kepler.put('/90ebb45f-ad77-5c30-ab90-1b7e389f3398')
     store = tempfile.mkdtemp()
     runner.invoke(main, ['run', layers_dir, store, 'mock://example.com',
-                         '--namespace', 'foo.bar'])
+                         '--namespace', 'foo.bar', '--s3-key', 'foo',
+                         '--s3-secret', 'bar'])
     assert kepler.call_count == 2
     assert kepler.request_history[0].url == \
         'mock://example.com/90ebb45f-ad77-5c30-ab90-1b7e389f3398'
 
 
-def test_run_uses_authentication(runner, layers_dir, kepler):
+def test_run_uses_authentication(runner, layers_dir, kepler, s3):
     store = tempfile.mkdtemp()
     runner.invoke(main, ['run', layers_dir, store, 'mock://example.com/404',
-                         '--username', 'foo', '--password', 'bar'])
+                         '--username', 'foo', '--password', 'bar',
+                         '--s3-key', 'foo', '--s3-secret', 'bar'])
     assert kepler.request_history[0].headers['Authorization'] == \
         'Basic Zm9vOmJhcg=='
 
 
-def test_run_logs_uploaded_layers_to_stdout(runner, layers_dir, kepler):
+def test_run_logs_uploaded_layers_to_stdout(runner, layers_dir, kepler, s3):
     store = tempfile.mkdtemp()
     res = runner.invoke(main, ['run', layers_dir, store,
-                               'mock://example.com/404'])
+                               'mock://example.com/404', '--s3-key', 'foo',
+                               '--s3-secret', 'bar'])
     assert 'SDE_DATA_BD_A8GNS_2003 uploaded' in res.output
 
 
-def test_run_logs_failed_layers_to_stdout(runner, layers_dir, kepler):
-    kepler.register_uri('PUT', requests_mock.ANY, status_code=500)
+def test_run_logs_failed_layers_to_stdout(runner, layers_dir, kepler, s3):
+    kepler.put(requests_mock.ANY, status_code=500)
     store = tempfile.mkdtemp()
     res = runner.invoke(main, ['run', layers_dir, store,
-                               'mock://example.com/404'])
+                               'mock://example.com/404', '--s3-key', 'foo',
+                               '--s3-secret', 'bar'])
     assert 'SDE_DATA_BD_A8GNS_2003 failed' in res.output
 
 
-def test_run_fails_after_consecutive_failures(runner, layers_dir, kepler):
-    kepler.register_uri('PUT', requests_mock.ANY, status_code=500)
+def test_run_fails_after_consecutive_failures(runner, layers_dir, kepler, s3):
+    kepler.put(requests_mock.ANY, status_code=500)
     store = tempfile.mkdtemp()
     res = runner.invoke(main, ['run', layers_dir, store,
-                               'mock://example.com/404', '--fail-after', 1])
+                               'mock://example.com/404', '--fail-after', 1,
+                               '--s3-key', 'foo', '--s3-secret', 'bar'])
     assert 'Maximum number of consecutive failures' in res.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-import os.path
+import os
 import tempfile
 
 from click.testing import CliRunner
-import mock
 import pytest
 import requests_mock
 
@@ -16,73 +15,69 @@ def runner():
     return CliRunner()
 
 
-def test_run_submits_bags(runner, layers_dir):
-    with requests_mock.Mocker() as m:
-        store = tempfile.mkdtemp()
-        m.post('http://localhost')
-        res = runner.invoke(main, ['run', layers_dir, store,
-                                   'http://localhost'])
+def test_run_submits_job(runner, layers_dir, kepler):
+    store = tempfile.mkdtemp()
+    res = runner.invoke(main, ['run', layers_dir, store,
+                               'mock://example.com/404'])
     assert res.exit_code == 0
-    assert m.request_history[0].method == 'POST'
+    assert kepler.request_history[0].method == 'GET'
+    assert kepler.request_history[1].method == 'PUT'
 
 
-def test_run_leaves_bag_on_success(runner, layers_dir):
-    with requests_mock.Mocker() as m:
-        store = tempfile.mkdtemp()
-        m.post('http://localhost')
-        runner.invoke(main, ['run', layers_dir, store, 'http://localhost'])
-        assert os.path.isdir(os.path.join(store, 'SDE_DATA_BD_A8GNS_2003'))
+def test_run_leaves_bag_on_success(runner, layers_dir, kepler):
+    store = tempfile.mkdtemp()
+    runner.invoke(main, ['run', layers_dir, store, 'mock://example.com/404'])
+    bag = os.path.join(store, 'SDE_DATA_BD_A8GNS_2003/data')
+    assert 'SDE_DATA_BD_A8GNS_2003.zip' in os.listdir(bag)
+    assert 'SDE_DATA_BD_A8GNS_2003.xml' in os.listdir(bag)
 
 
-def test_run_removes_bag_on_failure(runner, layers_dir):
-    with requests_mock.Mocker() as m:
-        store = tempfile.mkdtemp()
-        m.post('http://localhost', status_code=500)
-        runner.invoke(main, ['run', layers_dir, store, 'http://localhost'])
-        assert not os.path.isdir(os.path.join(store, 'SDE_DATA_BD_A8GNS_2003'))
+def test_run_removes_bag_on_failure(runner, layers_dir, kepler):
+    kepler.register_uri('PUT', requests_mock.ANY, status_code=500)
+    store = tempfile.mkdtemp()
+    res = runner.invoke(main, ['run', layers_dir, store,
+                               'mock://example.com/404'])
+    assert res.exit_code == 0
+    assert not os.path.isdir(os.path.join(store, 'SDE_DATA_BD_A8GNS_2003'))
 
 
-def test_run_uses_supplied_namespace(runner, layers_dir):
-    with mock.patch('slingshot.cli.submit') as m:
-        store = tempfile.mkdtemp()
-        runner.invoke(main, ['run', layers_dir, store, 'http://localhost',
-                             '--namespace', 'foo.bar'])
-    assert os.path.basename(m.call_args[0][0]) == \
-        '90ebb45f-ad77-5c30-ab90-1b7e389f3398.zip'
+def test_run_uses_supplied_namespace(runner, layers_dir, kepler):
+    kepler.get('/90ebb45f-ad77-5c30-ab90-1b7e389f3398', status_code=404)
+    kepler.put('/90ebb45f-ad77-5c30-ab90-1b7e389f3398')
+    store = tempfile.mkdtemp()
+    runner.invoke(main, ['run', layers_dir, store, 'mock://example.com',
+                         '--namespace', 'foo.bar'])
+    assert kepler.call_count == 2
+    assert kepler.request_history[0].url == \
+        'mock://example.com/90ebb45f-ad77-5c30-ab90-1b7e389f3398'
 
 
-def test_run_uses_authentication(runner, layers_dir):
-    with requests_mock.Mocker() as m:
-        store = tempfile.mkdtemp()
-        m.post('http://localhost')
-        runner.invoke(main, ['run', layers_dir, store, 'http://localhost',
-                             '--username', 'foo', '--password', 'bar'])
-    assert m.request_history[0].headers['Authorization'] == \
+def test_run_uses_authentication(runner, layers_dir, kepler):
+    store = tempfile.mkdtemp()
+    runner.invoke(main, ['run', layers_dir, store, 'mock://example.com/404',
+                         '--username', 'foo', '--password', 'bar'])
+    assert kepler.request_history[0].headers['Authorization'] == \
         'Basic Zm9vOmJhcg=='
 
 
-def test_run_logs_uploaded_layers_to_stdout(runner, layers_dir):
-    with requests_mock.Mocker() as m:
-        store = tempfile.mkdtemp()
-        m.post('http://localhost')
-        res = runner.invoke(main, ['run', layers_dir, store,
-                                   'http://localhost'])
-        assert 'SDE_DATA_BD_A8GNS_2003.zip uploaded' in res.output
+def test_run_logs_uploaded_layers_to_stdout(runner, layers_dir, kepler):
+    store = tempfile.mkdtemp()
+    res = runner.invoke(main, ['run', layers_dir, store,
+                               'mock://example.com/404'])
+    assert 'SDE_DATA_BD_A8GNS_2003 uploaded' in res.output
 
 
-def test_run_logs_failed_layers_to_stdout(runner, layers_dir):
-    with requests_mock.Mocker() as m:
-        store = tempfile.mkdtemp()
-        m.post('http://localhost', status_code=500)
-        res = runner.invoke(main, ['run', layers_dir, store,
-                                   'http://localhost'])
-        assert 'SDE_DATA_BD_A8GNS_2003.zip failed' in res.output
+def test_run_logs_failed_layers_to_stdout(runner, layers_dir, kepler):
+    kepler.register_uri('PUT', requests_mock.ANY, status_code=500)
+    store = tempfile.mkdtemp()
+    res = runner.invoke(main, ['run', layers_dir, store,
+                               'mock://example.com/404'])
+    assert 'SDE_DATA_BD_A8GNS_2003 failed' in res.output
 
 
-def test_run_fails_after_consecutive_failures(runner, layers_dir):
-    with requests_mock.Mocker() as m:
-        store = tempfile.mkdtemp()
-        m.post('http://localhost', status_code=500)
-        res = runner.invoke(main, ['run', layers_dir, store,
-                                   'http://localhost', '--fail-after', 1])
-        assert 'Maximum number of consecutive failures' in res.output
+def test_run_fails_after_consecutive_failures(runner, layers_dir, kepler):
+    kepler.register_uri('PUT', requests_mock.ANY, status_code=500)
+    store = tempfile.mkdtemp()
+    res = runner.invoke(main, ['run', layers_dir, store,
+                               'mock://example.com/404', '--fail-after', 1])
+    assert 'Maximum number of consecutive failures' in res.output

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ commands = py.test {posargs:--tb=short}
 deps =
     pytest
     mock
+    moto
     requests_mock
     -r{toxinidir}/requirements.txt
 


### PR DESCRIPTION
This PR changes slingshot to submit the bag to S3 first, then create a kepler job using the S3 resource key. Because the job will now be run asynchronously, slingshot queries kepler for the most recent job status of each layer before creating a new job.