### PR TITLE
Overwrite existing bag in store

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@ sudo: false
 notifications:
   email: false
 language: python
-env:
-  - TOX_ENV=py27
-  - TOX_ENV=py33
-  - TOX_ENV=py34
-  - TOX_ENV=coveralls
+matrix:
+  include:
+    - env: TOX_ENV=py27
+    - python: 3.5
+      env: TOX_ENV=py35
+    - env: TOX_ENV=coveralls
 install:
   - pip install tox
 script:

--- a/slingshot/app.py
+++ b/slingshot/app.py
@@ -40,7 +40,11 @@ class Kepler(object):
 
 def make_bag_dir(layer_name, destination):
     extracted = os.path.join(destination, layer_name)
-    os.mkdir(extracted)
+    try:
+        os.mkdir(extracted)
+    except OSError:
+        shutil.rmtree(extracted)
+        os.mkdir(extracted)
     return extracted
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -28,7 +28,7 @@ def test_make_bag_dir_returns_dir_name(upload_dir):
 def test_make_bag_dir_overwrites_existing_dir(upload_dir):
     bag = os.path.join(upload_dir, 'TEST_BAG')
     os.mkdir(bag)
-    with open(os.path.join(bag, 'foobar'), 'wb') as fp:
+    with open(os.path.join(bag, 'foobar'), 'w') as fp:
         fp.write("I shouldn't be here.")
     make_bag_dir('TEST_BAG', upload_dir)
     assert not os.path.isfile(os.path.join(bag, 'foobar'))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -25,6 +25,15 @@ def test_make_bag_dir_returns_dir_name(upload_dir):
         os.path.join(upload_dir, 'TEST_BAG')
 
 
+def test_make_bag_dir_overwrites_existing_dir(upload_dir):
+    bag = os.path.join(upload_dir, 'TEST_BAG')
+    os.mkdir(bag)
+    with open(os.path.join(bag, 'foobar'), 'wb') as fp:
+        fp.write("I shouldn't be here.")
+    make_bag_dir('TEST_BAG', upload_dir)
+    assert not os.path.isfile(os.path.join(bag, 'foobar'))
+
+
 def test_write_fgdc_writes_fgdc(shapefile, upload_dir):
     write_fgdc(shapefile, os.path.join(upload_dir, 'test.xml'))
     assert os.path.isfile(os.path.join(upload_dir, 'test.xml'))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,coverage
+envlist = py27,py35,coverage
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Slingshot will overwrite a bag with the same name in the store. The
assumption is that the layer names are static and we always want the
most recent version.