### PR TITLE
Skip existing layers

### DIFF
--- a/slingshot/app.py
+++ b/slingshot/app.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+
 import base64
 import json
 import os
-import shutil
 import tempfile
 import uuid
 from zipfile import ZipFile
@@ -33,18 +33,6 @@ def unpack_zip(source, destination):
             f_dest = os.path.join(destination, os.path.basename(f))
             with open(f_dest, 'wb') as fp:
                 fp.write(zf.read(f))
-
-
-def make_bag_dir(destination, overwrite=False):
-    try:
-        os.mkdir(destination)
-    except OSError:
-        if overwrite:
-            shutil.rmtree(destination)
-            os.mkdir(destination)
-        else:
-            raise
-    return destination
 
 
 def create_record(bag, public, secure, **kwargs):

--- a/slingshot/cli.py
+++ b/slingshot/cli.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+
 import os
 import shutil
 import traceback
@@ -10,7 +11,6 @@ from slingshot.app import (
     create_record,
     GeoBag,
     index_layer,
-    make_bag_dir,
     make_slug,
     register_layer,
     unpack_zip,
@@ -60,7 +60,12 @@ def bag(layers, bags, db_uri, workspace, public, secure):
         zips = [layers]
     for layer in zips:
         name = os.path.splitext(os.path.basename(layer))[0]
-        dest = make_bag_dir(os.path.join(bags, name))
+        dest = os.path.join(bags, name)
+        try:
+            os.mkdir(dest)
+        except OSError:
+            click.echo('Skipping existing layer {}'.format(name))
+            continue
         try:
             unpack_zip(layer, dest)
             bag = GeoBag.create(dest)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,7 +12,6 @@ from slingshot.app import (
     GeoBag,
     get_srid,
     index_layer,
-    make_bag_dir,
     make_slug,
     make_uuid,
     register_layer,
@@ -28,33 +27,6 @@ def temp_dir():
 def test_unpack_zip_extracts_to_top_of_dir(shapefile, temp_dir):
     unpack_zip(shapefile, temp_dir)
     assert os.path.isfile(os.path.join(temp_dir, 'bermuda.shp'))
-
-
-def test_make_bag_dir_creates_directory(temp_dir):
-    target = os.path.join(temp_dir, 'TEST_BAG')
-    make_bag_dir(target)
-    assert os.path.isdir(target)
-
-
-def test_make_bag_dir_returns_dir_name(temp_dir):
-    target = os.path.join(temp_dir, 'TEST_BAG')
-    assert make_bag_dir(target) == target
-
-
-def test_make_bag_dir_raises_error_when_dir_exists(temp_dir):
-    bag = os.path.join(temp_dir, 'TEST_BAG')
-    os.mkdir(bag)
-    with pytest.raises(OSError):
-        make_bag_dir(bag)
-
-
-def test_make_bag_dir_overwrites_existing_dir(temp_dir):
-    bag = os.path.join(temp_dir, 'TEST_BAG')
-    os.mkdir(bag)
-    with open(os.path.join(bag, 'foobar'), 'w') as fp:
-        fp.write("I shouldn't be here.")
-    make_bag_dir(bag, overwrite=True)
-    assert not os.path.isfile(os.path.join(bag, 'foobar'))
 
 
 def test_create_record_creates_mit_record(bag):


### PR DESCRIPTION
Rather than throwing an exception for existing layers, this will now
just skip them and print a message about doing so.