### PR TITLE
Add streaming reader for Postgres COPY

### DIFF
--- a/slingshot/db.py
+++ b/slingshot/db.py
@@ -1,4 +1,5 @@
 from geoalchemy2 import Geometry
+from geomet import wkt
 from sqlalchemy import (
     Boolean,
     Column,
@@ -61,11 +62,8 @@ def prep_field(field, _type, encoding):
     if field is None:
         return r'\N'
     if _type == 'C':
-        try:
-            # This could be either bytes or unicode
+        if type(field) is bytes:
             field = field.decode(encoding)
-        except:
-            pass
         quotable = (u'\t', u'\n', u'\r', u'\.')
         for q in quotable:
             field = field.replace(q, u'\\' + q)
@@ -91,3 +89,54 @@ def multiply(geometry):
             'coordinates': [geometry['coordinates']]
         }
     return geometry
+
+
+class PGShapeReader(object):
+    """Implements file-like interface to shapefile for PG COPY command.
+
+    A ``PGShapeReader`` provides a streaming interface to a Shapefile for
+    passing to a ``psycopg2`` cursor's ``copy_from`` method. The class
+    requires a ``shapefile.Reader`` object from
+    `pyshp <https://github.com/GeospatialPython/pyshp>`_.
+    """
+    def __init__(self, shapefile, srid, encoding='utf-8'):
+        self.shapefile = shapefile
+        self.srid = srid
+        self.encoding = encoding
+        self._f_types = [f[1] for f in self.shapefile.fields[1:]]
+        self._g = self.shapefile.iterShapeRecords()
+        self._buffer = u''
+
+    def read(self, size=-1):
+        if size <= 0:
+            while True:
+                try:
+                    self._read_into_buffer()
+                except StopIteration:
+                    return self._buffer
+        while len(self._buffer) < size:
+            try:
+                self._read_into_buffer()
+            except StopIteration:
+                break
+        buf = self._buffer[:size]
+        self._buffer = self._buffer[size:]
+        return buf
+
+    def readline(self):
+        try:
+            record = next(self._g)
+        except StopIteration:
+            return u''
+        return self._record_to_str(record)
+
+    def _read_into_buffer(self):
+        record = next(self._g)
+        self._buffer += self._record_to_str(record)
+
+    def _record_to_str(self, record):
+        geom = u'SRID={};{}'.format(
+            self.srid, wkt.dumps(multiply(record.shape.__geo_interface__)))
+        fields = [prep_field(f, f_type, self.encoding) for f, f_type in
+                  zip(record.record, self._f_types)] + [geom]
+        return u'\t'.join(fields) + u'\n'


### PR DESCRIPTION
This replaces the tempfile approach to a streaming interface to the
shapefile. The PGShapeReader can be passed to psycopg2's copy_from
method on the cursor object.