### PR TITLE
Remove the system install from tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ setenv =
     {integration,coverage}: PYTEST_ARGS=tests/integration
     coverage: PYTEST_COV="--cov=slingshot"
 commands =
-    pipenv install --dev --system
+    pipenv install --dev
     py.test tests/unit {env:PYTEST_ARGS:} {env:PYTEST_COV:} {posargs:--tb=short}
 
 [testenv:flake8]
@@ -23,7 +23,7 @@ commands = flake8
 [testenv:coveralls]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH POSTGIS_DB
 commands =
-    pipenv install --dev --system
+    pipenv install --dev
     py.test tests --cov=slingshot
     coveralls
 


### PR DESCRIPTION
A recent change to pipenv means this is no longer necessary. It will
detect it is being run in a virtualenv created by tox and just install
dependencies into that.