### PR TITLE
Remove Python 2 cruft

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Slingshot
 =========

--- a/slingshot/__init__.py
+++ b/slingshot/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Slingshot
 """

--- a/slingshot/app.py
+++ b/slingshot/app.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 import base64
 import json
 import os
@@ -64,16 +61,8 @@ def register_layer(layer_name, geoserver, workspace, datastore, auth=None):
 
 
 def make_uuid(value, namespace='mit.edu'):
-    try:
-        ns = uuid.uuid5(uuid.NAMESPACE_DNS, namespace)
-        uid = uuid.uuid5(ns, value)
-    except UnicodeDecodeError:  # pragma: no cover
-        # Python 2 requires a byte string for the second argument.
-        # Python 3 requires a unicode string for the second argument.
-        value, namespace = [bytearray(s, 'utf-8') for s in (value, namespace)]
-        ns = uuid.uuid5(uuid.NAMESPACE_DNS, namespace)
-        uid = uuid.uuid5(ns, value)
-    return uid
+    ns = uuid.uuid5(uuid.NAMESPACE_DNS, namespace)
+    return uuid.uuid5(ns, value)
 
 
 def make_slug(name):
@@ -129,18 +118,15 @@ class GeoBag(object):
     def record(self):
         if self._record is None:
             rec = os.path.join(self.payload_dir, 'gbl_record.json')
-            with open(rec) as fp:
+            with open(rec, encoding="utf-8") as fp:
                 self._record = json.load(fp)
         return self._record
 
     @record.setter
     def record(self, value):
         path = os.path.join(self.payload_dir, 'gbl_record.json')
-        s = json.dumps(value)
-        if not isinstance(s, bytes):
-            s = s.encode('utf-8')
-        with open(path, 'wb') as fp:
-            fp.write(s)
+        with open(path, 'w', encoding="utf-8") as fp:
+            json.dump(value, fp, ensure_ascii=False)
         self._record = value
 
     @property

--- a/slingshot/cli.py
+++ b/slingshot/cli.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 import os
 import shutil
 import traceback

--- a/slingshot/parsers.py
+++ b/slingshot/parsers.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
 try:
     from lxml.etree import iterparse
 except ImportError:

--- a/slingshot/record.py
+++ b/slingshot/record.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 import json
 import arrow
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
 import os
 import shutil
 import tempfile

--- a/tests/integration/test_command_line.py
+++ b/tests/integration/test_command_line.py
@@ -1,10 +1,7 @@
 import os
 import shutil
 import tempfile
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 from click.testing import CliRunner
 from dotenv import load_dotenv, find_dotenv

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
 import os
 import tempfile
 import uuid
@@ -87,11 +85,6 @@ def test_make_uuid_creates_uuid_string():
         uuid.UUID('df04b29c-0e51-58a8-8a37-557e4f4917df')
 
 
-def test_make_uuid_works_with_unicode_values():
-    assert make_uuid(u'bermuda', u'mit.edu') == \
-        uuid.UUID('df04b29c-0e51-58a8-8a37-557e4f4917df')
-
-
 def test_make_slug_creates_slug():
     assert make_slug('bermuda') == 'mit-34clfhaokfmkq'
 
@@ -119,10 +112,10 @@ def test_geobag_returns_record(bag):
 
 def test_geobag_writes_record(bag):
     b = GeoBag(bag)
-    b.record = {'foo': 'bar'}
+    b.record = {'foo': 'ɓar'}
     with open(os.path.join(b.payload_dir, 'gbl_record.json')) as fp:
         rec = fp.read()
-    assert rec == '{\"foo\": \"bar\"}'
+    assert rec == '{\"foo\": \"ɓar\"}'
 
 
 def test_geobag_returns_path_to_fgdc(bag):


### PR DESCRIPTION
We're no longer supporting Python 2. This mostly just removes some
boiler plate that's no longer required, with a few changes having to do
with strings vs bytes.

Closes #45.