### PR TITLE
Use new pipenv features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
     - python: 3.6
       env: TOX_ENV=flake8
     - python: 3.6
+      env: TOX_ENV=safety
+    - python: 3.6
       env: TOX_ENV=coveralls
 before_script:
     - psql -U postgres -c "CREATE DATABASE slingshot_test;"

--- a/tests/integration/test_command_line.py
+++ b/tests/integration/test_command_line.py
@@ -4,7 +4,6 @@ import tempfile
 from unittest.mock import patch
 
 from click.testing import CliRunner
-from dotenv import load_dotenv, find_dotenv
 import pytest
 
 from slingshot.cli import main
@@ -18,7 +17,6 @@ def runner():
 
 @pytest.fixture
 def db():
-    load_dotenv(find_dotenv())
     uri = os.environ.get('POSTGIS_DB')
     engine.configure(uri)
     return engine

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = py36,py36-integration,coverage,flake8
+envlist = py36,py36-integration,coverage,flake8,safety
 
 [testenv]
 passenv = HOME POSTGIS_DB
 basepython = python3.6
 deps =
     pipenv
-    python-dotenv
     {coverage,coveralls}: pytest-cov
     coveralls: coveralls
 setenv =
@@ -14,11 +13,13 @@ setenv =
     coverage: PYTEST_COV="--cov=slingshot"
 commands =
     pipenv install --dev
-    py.test tests/unit {env:PYTEST_ARGS:} {env:PYTEST_COV:} {posargs:--tb=short}
+    pipenv run py.test tests/unit {env:PYTEST_ARGS:} {env:PYTEST_COV:} {posargs:--tb=short}
 
 [testenv:flake8]
-deps = flake8
-commands = flake8
+commands = pipenv check --style slingshot
+
+[testenv:safety]
+commands = pipenv check
 
 [testenv:coveralls]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH POSTGIS_DB


### PR DESCRIPTION
Pipenv now includes flake8 and dotenv loading by default, so we no
longer need to specify these as dependencies. This also adds a tox
environment for running the new safety check feature in Pipenv. CI
builds will fail if any security problems are discovered in third party
dependencies.