### PR TITLE
Refactors the record object

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,19 +1,24 @@
 [[source]]
+
 verify_ssl = true
 url = "https://pypi.python.org/simple"
 
+
 [packages]
-arrow = "*"
+
 bagit = "*"
 click = "*"
 geomet = "*"
-psycopg2-binary = "*"
+"psycopg2-binary" = "*"
 pyshp = "*"
 requests = "*"
-GeoAlchemy2 = "*"
+"GeoAlchemy2" = "*"
 PlyPlus = "*"
+attr = "*"
+
 
 [dev-packages]
+
 bumpversion = "*"
 coveralls = "*"
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d26f51f813daf55179f647edd7b27dfdce1e0f1fab4421f01a54c96a60a5f2d1"
+            "sha256": "1f04d1cbc70420177c4aa495aed0488c97ff39d5b3f1df6da753ba66ef647b98"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
@@ -9,9 +9,9 @@
             "os_name": "posix",
             "platform_machine": "x86_64",
             "platform_python_implementation": "CPython",
-            "platform_release": "4.9.0-5-amd64",
+            "platform_release": "4.9.0-6-amd64",
             "platform_system": "Linux",
-            "platform_version": "#1 SMP Debian 4.9.65-3+deb9u2 (2018-01-04)",
+            "platform_version": "#1 SMP Debian 4.9.82-1+deb9u3 (2018-03-02)",
             "python_full_version": "3.6.2",
             "python_version": "3.6",
             "sys_platform": "linux"
@@ -26,17 +26,18 @@
         ]
     },
     "default": {
-        "arrow": {
+        "attr": {
             "hashes": [
-                "sha256:a558d3b7b6ce7ffc74206a86c147052de23d3d4ef0e17c210dd478c53575c4cd"
+                "sha256:0b1aaddb85bd9e9c4bd75092f4440d6616ff40b0df0437f00771871670f7c9fd",
+                "sha256:9091548058d17f132596e61fa7518e504f76b9a4c61ca7d86e1f96dbf7d4775d"
             ],
-            "version": "==0.12.1"
+            "version": "==0.3.1"
         },
         "bagit": {
             "hashes": [
-                "sha256:0f5e7138511ac4a703e67aab709c755e58993cea9707ad163941fbbc24e62b4a"
+                "sha256:91c5e253ad4ae0c5a5e795c689cda348c01286c671e9f6ca5cab0018980f9be9"
             ],
-            "version": "==1.6.3"
+            "version": "==1.6.4"
         },
         "certifi": {
             "hashes": [
@@ -81,9 +82,10 @@
         },
         "ply": {
             "hashes": [
-                "sha256:96e94af7dd7031d8d6dd6e2a8e0de593b511c211a86e28a9c9621c275ac8bacb"
+                "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce",
+                "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"
             ],
-            "version": "==3.10"
+            "version": "==3.11"
         },
         "plyplus": {
             "hashes": [
@@ -129,13 +131,6 @@
             ],
             "version": "==1.2.12"
         },
-        "python-dateutil": {
-            "hashes": [
-                "sha256:95511bae634d69bc7329ba55e646499a842bc4ec342ad54a8cdb65645a0aad3c",
-                "sha256:891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca"
-            ],
-            "version": "==2.6.1"
-        },
         "requests": {
             "hashes": [
                 "sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b",
@@ -152,9 +147,9 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:64b4720f0a8e033db0154d3824f5bf677cf2797e11d44743cf0aebd2a0499d9d"
+                "sha256:249000654107a420a40200f1e0b555a79dfd4eff235b2ff60bc77714bd045f2d"
             ],
-            "version": "==1.2.2"
+            "version": "==1.2.5"
         },
         "urllib3": {
             "hashes": [
@@ -236,10 +231,10 @@
         },
         "coveralls": {
             "hashes": [
-                "sha256:84dd8c88c5754e8db70a682f537e2781366064aa3cdd6b24c2dcecbd3181187c",
-                "sha256:510682001517bcca1def9f6252df6ce730fcb9831c62d9fff7c7d55b6fdabdf3"
+                "sha256:32569a43c9dbc13fa8199247580a4ab182ef439f51f65bb7f8316d377a1340e8",
+                "sha256:664794748d2e5673e347ec476159a9d87f43e0d2d44950e98ed0e27b98da8346"
             ],
-            "version": "==1.2.0"
+            "version": "==1.3.0"
         },
         "docopt": {
             "hashes": [
@@ -254,6 +249,14 @@
             ],
             "version": "==2.6"
         },
+        "more-itertools": {
+            "hashes": [
+                "sha256:11a625025954c20145b37ff6309cd54e39ca94f72f6bb9576d1195db6fa2442e",
+                "sha256:0dd8f72eeab0d2c3bd489025bb2f6a1b8342f9b198f6fc37b52d15cfa4531fea",
+                "sha256:c9ce7eccdcb901a2c75d326ea134e0886abfbea5f93e91cc95de9507c0816c44"
+            ],
+            "version": "==4.1.0"
+        },
         "pluggy": {
             "hashes": [
                 "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff"
@@ -262,17 +265,17 @@
         },
         "py": {
             "hashes": [
-                "sha256:8cca5c229d225f8c1e3085be4fcf306090b00850fefad892f9d96c7b6e2f310f",
-                "sha256:ca18943e28235417756316bfada6cd96b23ce60dd532642690dcfdaba988a76d"
+                "sha256:983f77f3331356039fdd792e9220b7b8ee1aa6bd2b25f567a963ff1de5a64f6a",
+                "sha256:29c9fab495d7528e80ba1e343b958684f4ace687327e6f789a94bf3d1915f881"
             ],
-            "version": "==1.5.2"
+            "version": "==1.5.3"
         },
         "pytest": {
             "hashes": [
-                "sha256:95fa025cd6deb5d937e04e368a00552332b58cae23f63b76c8c540ff1733ab6d",
-                "sha256:6074ea3b9c999bd6d0df5fa9d12dd95ccd23550df2a582f5f5b848331d2e82ca"
+                "sha256:6266f87ab64692112e5477eba395cfedda53b1933ccd29478e671e73b420c19c",
+                "sha256:fae491d1874f199537fd5872b5e1f0e74a009b979df9d53d1553fd03da1703e1"
             ],
-            "version": "==3.4.0"
+            "version": "==3.5.0"
         },
         "pytest-cov": {
             "hashes": [

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 import uuid
 
+import attr
 import bagit
 import pytest
 import requests_mock
@@ -121,7 +122,7 @@ def test_geobag_returns_record(bag):
 
 def test_geobag_writes_record_on_save(bag):
     b = GeoBag(bagit.Bag(bag))
-    b.record.dc_title_s = 'Fooɓar'
+    b.record = attr.evolve(b.record, dc_title_s='Fooɓar')
     b.save()
     with open(os.path.join(b.payload_dir, 'gbl_record.json')) as fp:
         rec = json.load(fp)
@@ -149,7 +150,7 @@ def test_shapebag_returns_path_to_cst_file(bag):
 
 def test_geobag_updates_bag_on_save(bag):
     b = GeoBag(bagit.Bag(bag))
-    b.record.dc_title_s = 'foobar'
+    b.record = attr.evolve(b.record, dc_title_s='foobar')
     b.save()
     assert b.is_valid()
 

--- a/tests/unit/test_record.py
+++ b/tests/unit/test_record.py
@@ -1,49 +1,41 @@
-import arrow
+from datetime import datetime, timedelta
 
-from slingshot.record import (
-    geometry_mapper,
-    MitRecord,
-    rights_mapper,
-)
+from slingshot.record import Record, rights_converter, geom_converter
 
 
-def test_mit_record_maps_rights():
-    r = MitRecord(dc_rights_s='Unrestricted Access')
+def test_record_maps_rights():
+    r = Record(dc_rights_s='Unrestricted Access')
     assert r.dc_rights_s == 'Public'
 
 
-def test_mit_record_maps_geom():
-    r = MitRecord(layer_geom_type_s='Entity point')
+def test_record_maps_geom():
+    r = Record(layer_geom_type_s='Entity point')
     assert r.layer_geom_type_s == 'Point'
 
 
-def test_mit_record_defaults_to_mit():
-    r = MitRecord()
+def test_record_defaults_to_mit():
+    r = Record()
     r.dct_provenance_s == 'MIT'
 
 
-def test_mit_record_defaults_to_now_for_modified_time():
-    now = arrow.utcnow()
-    r = MitRecord()
+def test_record_defaults_to_now_for_modified_time():
+    now = datetime.utcnow()
+    td = timedelta(seconds=1)
+    r = Record()
     assert r.layer_modified_dt is not None
-    assert now.shift(minutes=-1) < arrow.get(r.layer_modified_dt) < \
-        now.shift(minutes=+1)
+    dt = datetime.strptime(r.layer_modified_dt, '%Y-%m-%dT%H:%M:%SZ')
+    assert (now - td) < dt < (now + td)
 
 
-def test_mit_record_formats_datetime():
-    r = MitRecord(layer_modified_dt='2000-10-31 23:59:59')
-    assert r.layer_modified_dt == '2000-10-31T23:59:59Z'
+def test_rights_converter_maps_rights():
+    assert rights_converter('Unrestricted layer') == 'Public'
+    assert rights_converter('rEsTrIcted layer') == 'Restricted'
+    assert rights_converter('Public') == 'Public'
 
 
-def test_rights_mapper_maps_rights():
-    assert rights_mapper('Unrestricted layer') == 'Public'
-    assert rights_mapper('rEsTrIcted layer') == 'Restricted'
-    assert rights_mapper('Public') == 'Public'
-
-
-def testGeometryMapperNormalizesTerm():
-    assert geometry_mapper('a point or two') == 'Point'
-    assert geometry_mapper('here is a string, yo') == 'Line'
-    assert geometry_mapper('however, this is a polygon') == 'Polygon'
-    assert geometry_mapper('Line') == 'Line'
-    assert geometry_mapper('Composite Object') == 'Mixed'
+def test_geom_convert_maps_geometry():
+    assert geom_converter('a point or two') == 'Point'
+    assert geom_converter('here is a string, yo') == 'Line'
+    assert geom_converter('however, this is a polygon') == 'Polygon'
+    assert geom_converter('Line') == 'Line'
+    assert geom_converter('Composite Object') == 'Mixed'


### PR DESCRIPTION
The old record object was difficult to maintain and easy to break. This
has been replaced with an object based off of the third party `attrs`
module. This new record requires slightly more effort to use, but it's
much more difficult to misuse or make mistakes while modifying.

The implementation itself provides an almost entirely similar interface
for creation. The main differences are:

* Immutability; it is no longer possible to change a field once the
record has been created. (It's still possible to modify mutable fields
like dictionaries or lists.)
* Datetime fields must be correctly formatted before creation.
* The `solr_geom` field should be assembled before creating the record.