### PR TITLE
Add support for PG schemas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ matrix:
 before_script:
     - psql -U postgres -c "CREATE DATABASE slingshot_test;"
     - psql -U postgres -d slingshot_test -c "CREATE EXTENSION postgis;"
+    - psql -U postgres -d slingshot_test -c "CREATE SCHEMA geodata;"
 install:
   - pip install tox
 script:

--- a/slingshot/app.py
+++ b/slingshot/app.py
@@ -10,7 +10,7 @@ import bagit
 import requests
 from shapefile import Reader
 
-from slingshot.db import engine, table, PGShapeReader
+from slingshot.db import engine, table, PGShapeReader, table_name
 from slingshot.parsers import FGDCParser, parse
 from slingshot.proj import parser
 from slingshot.record import Record
@@ -346,10 +346,10 @@ def load_layer(bag):
             with engine().begin() as conn:
                 reader = PGShapeReader(sf, srid, encoding)
                 cursor = conn.connection.cursor()
-                cursor.copy_from(reader, '"{}"'.format(bag.name))
+                cursor.copy_from(reader, table_name(t))
             with engine().connect() as conn:
-                conn.execute('CREATE INDEX "idx_{}_geom" ON "{}" USING GIST '
-                             '(geom)'.format(bag.name, bag.name))
+                conn.execute('CREATE INDEX "idx_{}_geom" ON {} USING GIST '
+                             '(geom)'.format(bag.name, table_name(t)))
         except Exception:
             t.drop()
             raise

--- a/slingshot/db.py
+++ b/slingshot/db.py
@@ -25,7 +25,7 @@ class Engine(object):
 
 
 engine = Engine()
-metadata = MetaData()
+metadata = MetaData(schema='geodata')
 
 
 def table(name, gtype, srid, fields):
@@ -37,6 +37,12 @@ def table(name, gtype, srid, fields):
         gtype = 'MULTILINESTRING'
     cols.append(Column('geom', Geometry(gtype, srid, spatial_index=False)))
     return Table(name, metadata, *cols)
+
+
+def table_name(table):
+    schema = table.schema or 'public'
+    name = table.name
+    return '"{}"."{}"'.format(schema, name)
 
 
 def _make_column(field):

--- a/tests/integration/test_command_line.py
+++ b/tests/integration/test_command_line.py
@@ -24,7 +24,9 @@ def db():
 
 @pytest.fixture(autouse=True)
 def db_setup(db):
-    metadata.drop_all()
+    if db().has_table('bermuda', schema='geodata'):
+        with db().connect() as conn:
+            conn.execute("DROP TABLE geodata.bermuda")
     metadata.clear()
 
 
@@ -38,7 +40,7 @@ def test_bag_loads_shapefile(db, runner, shapefile):
                                'mock://example.com', layers, store])
     assert res.exit_code == 0
     with db().connect() as conn:
-        r = conn.execute('SELECT COUNT(*) FROM bermuda').scalar()
+        r = conn.execute('SELECT COUNT(*) FROM geodata.bermuda').scalar()
         assert r == 713
 
 


### PR DESCRIPTION
This adds support for putting the data layers into a separate PG schema.
It's a bit of a hack in its current state as the schema is hard coded as
``geodata``. This will need to be fixed to make it configurable. The
tests will also need to be updated to reflect this change.

The addition of schema support is necessary because both the spatial
data and the Rails app currently share the same table space. The better
approach will be to pull them out into separate spaces.