### PR TITLE
Add sub dir for TIFF directory

### DIFF
--- a/slingshot/app.py
+++ b/slingshot/app.py
@@ -77,10 +77,10 @@ class TiffHandler:
         self.bag = bag
         self.geoserver = geoserver
         self.workspace = workspace
-        self.destination = destination
         self.tiff_url = tiff_url
         access = 'public' if bag.is_public() else 'secure'
         self.server = self.geoserver.url(access)
+        self.destination = os.path.join(destination, access)
 
     def add(self):
         path = self._upload_layer(self.destination)
@@ -102,7 +102,7 @@ class TiffHandler:
         This just copies the Tiff file from the NFS partition to a
         directory served by Apache.
         """
-        tiff_path = shutil.copy(self.bag.tif, os.path.join(destination))
+        tiff_path = shutil.copy(self.bag.tif, destination)
         return "file:" + tiff_path
 
 


### PR DESCRIPTION
This will put the download copy of the TIFFs into a public/secure
subdirectory of the specified download directory.