### PR TITLE
Switch raster to image

### DIFF
--- a/slingshot/record.py
+++ b/slingshot/record.py
@@ -10,7 +10,7 @@ from attr import converters, validators
 
 RIGHTS = ('Public', 'Restricted')
 TYPES = ('Dataset', 'Image', 'Physical Object')
-GEOMS = ('Point', 'Line', 'Polygon', 'Raster', 'Scanned Map', 'Mixed')
+GEOMS = ('Point', 'Line', 'Polygon', 'Image', 'Raster', 'Mixed')
 
 env_regex = re.compile(
     "ENVELOPE\({}, {}, {}, {}\)".format(*repeat("[+-]?\d+(\.\d+)?", 4)))
@@ -48,7 +48,7 @@ def geom_converter(term):
     elif 'composite' in term.lower():
         return 'Mixed'
     elif 'raster' in term.lower():
-        return 'Raster'
+        return 'Image'
     return term
 
 


### PR DESCRIPTION
This changes the controlled vocab for `layer_geom_type_s` to align with
the current OGM schema. It's unclear how to differentiate between OGM
Raster and Image types based on FGDC. I think all our current raster
data should fall under the Image type.