### PR TITLE
Revert pip downgrade

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,12 +16,10 @@ commands =
     pipenv run py.test tests/unit {env:PYTEST_ARGS:} {env:PYTEST_COV:} {posargs:--tb=short}
 
 [testenv:flake8]
-commands = pip install pip==9.0.3
-           pipenv check --style slingshot
+commands = pipenv check --style slingshot
 
 [testenv:safety]
-commands = pip install pip==9.0.3
-           pipenv check
+commands = pipenv check
 
 [testenv:coveralls]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH POSTGIS_DB


### PR DESCRIPTION
Closes #69. The problematic packages seem to have fixed themselves. A
crisis has been averted, and the world once again rests firmly upon its
axis.