### PR TITLE
Add docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.7-alpine AS alpine
+RUN pip install --upgrade pip
+RUN apk --no-cache add build-base postgresql-dev
+RUN pip install pipenv
+
+FROM alpine AS wheel
+COPY . /slingshot/
+RUN cd /slingshot && python setup.py bdist_wheel
+
+FROM alpine
+COPY Pipfile* /
+RUN pipenv install --system --ignore-pipfile --deploy
+COPY --from=wheel /slingshot/dist/slingshot-*-py3-none-any.whl .
+RUN pip install slingshot-*-py3-none-any.whl
+
+ENTRYPOINT ["slingshot"]
+CMD ["--help"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean install wheel test tests update
+.PHONY: clean install dist test tests update
 SHELL=/bin/bash
 
 
@@ -15,8 +15,8 @@ clean: ## Remove build artifacts
 install: ## Install project and dev depenedencies
 	pipenv install --dev
 
-wheel: ## Build Python wheel
-	pipenv run python setup.py bdist_wheel
+dist: ## Build docker container
+	docker build -t slingshot .
 
 test: ## Run tests
 	tox

--- a/setup.py
+++ b/setup.py
@@ -6,22 +6,15 @@ GIS data workflow.
 """
 
 from setuptools import find_packages, setup
-import subprocess
 
 
 with open('LICENSE') as f:
     license = f.read()
 
-try:
-    output = subprocess.run(['git', 'describe', '--always'],
-                            stdout=subprocess.PIPE, encoding='utf-8')
-    version = output.stdout.strip()
-except subprocess.CalledProcessError:
-    version = 'unknown'
 
 setup(
     name='slingshot',
-    version='1.0.0-' + version,
+    version='1.0.0',
     description='GIS data workflow',
     long_description=__doc__,
     url='https://github.com/MITLibraries/slingshot',


### PR DESCRIPTION
This adds a Dockerfile for building the image. The wheel packaging step
has been moved into a docker stage for more consistency in the
build/deploy pipeline.

The git versioning for the app has been removed. It was always kind of
fragile and is more work to do in the container than it's probably
worth. git versions will be applied to the container tag during the
continuous integration process, so versioning will be managed at the
container level.