### PR TITLE
Make PostGres schema configurable at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,17 @@
 # slingshot
 
-This application provides workflow for spatial data. It can be used to create bags, add shapefiles to PostGIS and GeoServer, and index layers in a Solr instance for GeoBlacklight.
+This application provides workflow for spatial data. It will load a zipped layer from S3 into GeoServer and index it Solr.
 
 ## Installation
 
-These instructions will make a `slingshot` command available from your virtualenv.
-
-### With pipenv
+The easiest way to get started is to build the docker container and run that:
 
 ```bash
-$ mkdir slingshot && cd slinghost
-$ pipenv install https://github.com/MITLibraries/slingshot/zipball/v0.9.0
-$ pipenv run slingshot --version
+$ git clone git@github.com:MITLibraries/slingshot.git
+$ cd slingshot
+$ docker build -t slingshot .
+$ docker run --rm slingshot
 ```
-
-### With pip
-
-```bash
-$ python3 -m venv slingshot
-$ source slingshot/bin/activate
-(slingshot)$ pip install https://github.com/MITLibraries/slingshot/zipball/v0.9.0
-(slingshot)$ slingshot --version
-```
-
-## Usage
-
-You can view the help menu for the `slingshot` command with:
-
-```bash
-(slingshot)$ slingshot --help
-```
-
-The help menu for each subcommand can be viewed with:
-
-```bash
-(slingshot)$ slingshot <command> --help
-```
-
-### Commands
-
-#### bag
-
-The `bag` command will traverse a given directory of zipped shapefiles and perform the following actions:
-
-1. Unpack the zipfile to a new location
-2. Create a bag of the unpacked zipfile
-3. Add a GeoBlacklight metadata record to the bag called `geoblacklight.json`
-4. Load the shapefile into PostGIS
-
-If any of these steps fail, the bag will be removed.
-
-#### publish
-
-The `publish` command will traverse a given directory of bags and register each layer in GeoServer and add it to the Solr index. This effectively makes the layer available in GeoBlacklight.
-
-#### reindex
-
-The `reindex` command deletes all the shapefiles from the Solr index, traverses the given directory of bags, and reindexes each of the layers.
 
 ## Development
 
@@ -70,10 +25,16 @@ $ pipenv install --dev
 
 ### Running the Tests
 
-In order to run the integration tests you will need access to a PostGIS database. Add the SQLAlchemy connection URL to a `.env` file in the project root using the `POSTGIS_DB` variable. For example:
+In order to run the integration tests you will need access to a PostGIS database. Add the SQLAlchemy connection URL to a `.env` file in the project root using the `PG_DATABASE` variable. For example:
 
 ```
-POSTGIS_DB=postgresql://postgres@localhost/slingshot_test
+PG_DATABASE=postgresql://postgres@localhost/postgres
+```
+
+You can quickly set up a PostGIS database with docker:
+
+```
+$ docker run -p 5432:5432 mdillon/postgis
 ```
 
 Use [Tox](https://tox.readthedocs.io/en/latest/) to run the tests. You can see which environments are configured to run by default with:
@@ -83,22 +44,3 @@ $ tox -l
 ```
 
 If it seems like your tests are not picking up changes you've made, try running `make clean`. Usually, this problem arises after you've added new third party dependencies.
-
-### Creating a release
-
-1. Check out a new branch.
-2. Use the `release` target for `make` to create a new release.
-3. Push your new branch and tag, and follow the usual PR procedure.
-
-This will increment the version number, add a commit and create a git tag. By default the patch number will be incremented. You can change this by setting the `RELEASE_TYPE` variable when running `make`:
-
-```bash
-$ pipenv run slingshot --version
-slingshot, version 0.3.0
-$ git checkout -b new-release
-$ make release RELEASE_TYPE=minor
-Built release for v0.4.0. Make sure to run:
-  $ git push origin new-release tag v0.4.0
-```
-
-The `RELEASE_TYPE` variable supports the following settings: `major`, `minor` and `patch`.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ You can quickly set up a PostGIS database with docker:
 $ docker run -p 5432:5432 mdillon/postgis
 ```
 
+You should also consider adding the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to your `.env` file and set these to any dummy value. While this is not strictly necessary, it will help prevent you from accidentally using your real AWS credentials during testing/development.
+
 Use [Tox](https://tox.readthedocs.io/en/latest/) to run the tests. You can see which environments are configured to run by default with:
 
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'pyshp',
         'requests',
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.7.1',
     setup_requires=[
         'pytest-runner',
     ],

--- a/slingshot/cli.py
+++ b/slingshot/cli.py
@@ -19,19 +19,20 @@ def main():
 @click.argument('key')
 @click.argument('dest')
 @click.option('--db-uri', envvar='PG_DATABASE')
+@click.option('--db-schema', envvar='PG_SCHEMA', default='public')
 @click.option('--geoserver', envvar='GEOSERVER')
 @click.option('--geoserver-user', envvar='GEOSERVER_USER')
 @click.option('--geoserver-password', envvar='GEOSERVER_PASSWORD')
 @click.option('--solr', envvar='SOLR')
 @click.option('--solr-user', envvar='SOLR_USER')
 @click.option('--solr-password', envvar='SOLR_PASSWORD')
-def publish(bucket, key, dest, db_uri, geoserver, geoserver_user,
+def publish(bucket, key, dest, db_uri, db_schema, geoserver, geoserver_user,
             geoserver_password, solr, solr_user, solr_password):
     geo_auth = (geoserver_user, geoserver_password) if geoserver_user and \
         geoserver_password else None
     solr_auth = (solr_user, solr_password) if solr_user and solr_password \
         else None
-    engine.configure(db_uri)
+    engine.configure(db_uri, db_schema)
     geo_svc = GeoServer(geoserver, auth=geo_auth)
     solr_svc = Solr(solr, auth=solr_auth)
     layer = create_layer(*unpack_zip(bucket, key, dest))

--- a/slingshot/db.py
+++ b/slingshot/db.py
@@ -32,13 +32,24 @@ class Engine:
     def __call__(self):
         return self._engine
 
-    def configure(self, url):
+    def configure(self, url, schema=None):
         self._engine = self._engine or create_engine(url)
-        metadata.bind = self._engine
+        metadata.configure(schema=schema)
+        metadata().bind = self._engine
+
+
+class Metadata:
+    _metadata = None
+
+    def __call__(self):
+        return self._metadata
+
+    def configure(self, **kwargs):
+        self._metadata = self._metadata or MetaData(**kwargs)
 
 
 engine = Engine()
-metadata = MetaData(schema='geodata')
+metadata = Metadata()
 
 
 def table(name, gtype, srid, fields):
@@ -49,7 +60,7 @@ def table(name, gtype, srid, fields):
     elif gtype == 'LINESTRING':
         gtype = 'MULTILINESTRING'
     cols.append(Column('geom', Geometry(gtype, srid, spatial_index=False)))
-    return Table(name, metadata, *cols)
+    return Table(name, metadata(), *cols)
 
 
 def table_name(table):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -16,7 +16,8 @@ from slingshot.db import (
 
 @pytest.fixture(autouse=True)
 def reset_metadata():
-    metadata.clear()
+    metadata.configure(schema='public')
+    metadata().clear()
 
 
 def test_table_converts_to_multi_geom_type():


### PR DESCRIPTION
Closes #61. This adds a `--db-schema` command line option and a matching
`PG_SCHEMA` envvar. The schema defaults to `public`.