### PR TITLE
Add scripts section to Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -23,3 +23,6 @@ pytest = "*"
 pytest-cov = "*"
 requests-mock = "*"
 moto = "*"
+
+[scripts]
+slingshot = "python -c \"from slingshot.cli import main; main()\""

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ This application provides workflow for spatial data. It will load a zipped layer
 
 ## Installation
 
-The easiest way to get started is to build the docker container and run that:
+The easiest way to get started is to install using Pipenv:
 
 ```bash
 $ git clone git@github.com:MITLibraries/slingshot.git
 $ cd slingshot
-$ docker build -t slingshot .
-$ docker run --rm slingshot
+$ pipenv install
+$ pipenv run slingshot
 ```
 
 ## Development


### PR DESCRIPTION
This makes use of the scripts section in Pipfile to allow running
slingshot without having installed it into the virtualenv. The preferred
production deployment will still be to install slingshot as a package
but the Pipfile should be fine for local development.