### PR TITLE
Make GeoServer and Solr clients threadsafe

### DIFF
--- a/slingshot/cli.py
+++ b/slingshot/cli.py
@@ -1,8 +1,8 @@
 import click
 
 from slingshot import PUBLIC_WORKSPACE, RESTRICTED_WORKSPACE, DATASTORE
-from slingshot.app import (create_record, GeoServer, make_slug, Solr,
-                           unpack_zip,)
+from slingshot.app import (create_record, GeoServer, HttpSession, make_slug,
+                           Solr, unpack_zip,)
 from slingshot.db import engine, load_layer
 from slingshot.layer import create_layer
 from slingshot.marc import MarcParser
@@ -55,7 +55,7 @@ def initialize(geoserver, geoserver_user, geoserver_password, db_host, db_port,
     }
     geo_auth = (geoserver_user, geoserver_password) if geoserver_user and \
         geoserver_password else None
-    geo = GeoServer(geoserver, auth=geo_auth)
+    geo = GeoServer(geoserver, HttpSession(), auth=geo_auth)
     geo.post("/workspaces", json={"workspace": {"name": PUBLIC_WORKSPACE}})
     geo.post("/workspaces", json={"workspace": {"name": RESTRICTED_WORKSPACE}})
     geo.post("/workspaces/{}/datastores".format(PUBLIC_WORKSPACE),
@@ -114,8 +114,8 @@ def publish(bucket, key, dest, db_uri, db_schema, geoserver, geoserver_user,
     solr_auth = (solr_user, solr_password) if solr_user and solr_password \
         else None
     engine.configure(db_uri, db_schema)
-    geo_svc = GeoServer(geoserver, auth=geo_auth)
-    solr_svc = Solr(solr, auth=solr_auth)
+    geo_svc = GeoServer(geoserver, HttpSession(), auth=geo_auth)
+    solr_svc = Solr(solr, HttpSession(), auth=solr_auth)
     layer = create_layer(*(unpack_zip(bucket, key, dest, s3_endpoint)),
                          s3_endpoint)
     layer.record = create_record(layer, geoserver)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,6 +5,7 @@ import requests_mock
 from slingshot.app import (
     create_record,
     GeoServer,
+    HttpSession,
     make_slug,
     make_uuid,
     Solr,
@@ -30,7 +31,7 @@ def test_create_record_creates_record(shapefile_object):
 
 
 def test_geoserver_adds_shapefile(shapefile_object):
-    geoserver = GeoServer("mock://example.com/geoserver/")
+    geoserver = GeoServer("mock://example.com/geoserver/", HttpSession())
     with requests_mock.Mocker() as m:
         m.post("mock://example.com/geoserver/rest/workspaces/public/"
                "datastores/pg/featuretypes")
@@ -42,7 +43,7 @@ def test_geoserver_adds_shapefile(shapefile_object):
 def test_solr_adds_layer_to_solr():
     with requests_mock.Mocker() as m:
         m.post('mock://example.com/update/json/docs')
-        s = Solr('mock://example.com/')
+        s = Solr('mock://example.com/', HttpSession())
         s.add({'foo': 'bar'})
         assert m.request_history[0].json() == {'foo': 'bar'}
 
@@ -50,7 +51,7 @@ def test_solr_adds_layer_to_solr():
 def test_solr_deletes_by_query():
     with requests_mock.Mocker() as m:
         m.post('mock://example.com/update')
-        s = Solr('mock://example.com/')
+        s = Solr('mock://example.com/', HttpSession())
         s.delete()
         assert m.request_history[0].json() == \
             {'delete': {'query': 'dct_provenance_s:MIT'}}
@@ -59,7 +60,7 @@ def test_solr_deletes_by_query():
 def test_solr_commits_changes():
     with requests_mock.Mocker() as m:
         m.post('mock://example.com/update')
-        s = Solr('mock://example.com/')
+        s = Solr('mock://example.com/', HttpSession())
         s.commit()
         assert m.request_history[0].json() == {'commit': {}}
 


### PR DESCRIPTION
The publishing command will likely use multiple threads and most
information I can find online seems to agree that the requests.Session
object is not threadsafe.