### PR TITLE
Make boto3 session threadsafe

### DIFF
--- a/slingshot/app.py
+++ b/slingshot/app.py
@@ -5,13 +5,12 @@ import uuid
 from zipfile import ZipFile
 
 import attr
-import boto3
 import requests
 
 from slingshot import PUBLIC_WORKSPACE, RESTRICTED_WORKSPACE, DATASTORE
 from slingshot.parsers import FGDCParser, parse
 from slingshot.record import Record
-from slingshot.s3 import S3IO
+from slingshot.s3 import S3IO, session
 
 
 SUPPORTED_EXT = ('.shp', '.tif', '.tiff')
@@ -27,7 +26,7 @@ def unpack_zip(src_bucket, key, dest_bucket, endpoint=None):
     uploaded zipfile are removed leaving a flattened structure in the new
     object.
     """
-    s3 = boto3.resource('s3', endpoint_url=endpoint)
+    s3 = session().resource('s3', endpoint_url=endpoint)
     name = os.path.splitext(key)[0]
     obj = S3IO(s3.Object(src_bucket, key))
     bucket = s3.Bucket(dest_bucket)

--- a/slingshot/layer.py
+++ b/slingshot/layer.py
@@ -6,11 +6,9 @@ try:
 except ImportError:
     from xml.etree.ElementTree import iterparse
 
-import boto3
-
 from slingshot.proj import parser
 from slingshot.record import Record
-from slingshot.s3 import S3IO
+from slingshot.s3 import S3IO, session
 
 
 _LRU_CACHE_SIZE = 32
@@ -24,7 +22,7 @@ class S3Layer:
     necessary data files.
     """
     def __init__(self, bucket, key, endpoint=None):
-        self.s3 = boto3.resource('s3', endpoint_url=endpoint)
+        self.s3 = session().resource('s3', endpoint_url=endpoint)
         self.bucket = bucket
         self.key = key
         self.endpoint = endpoint
@@ -170,7 +168,7 @@ def create_layer(bucket, key, endpoint=None):
     Factory function that creates a new :class:`slingshot.s3.S3Layer` based
     on the given bucket and key.
     """
-    s3 = boto3.resource('s3', endpoint_url=endpoint)
+    s3 = session().resource('s3', endpoint_url=endpoint)
     bkt = s3.Bucket(bucket)
     for item in bkt.objects.filter(Prefix=key):
         if item.key.endswith('.shp'):

--- a/slingshot/s3.py
+++ b/slingshot/s3.py
@@ -1,4 +1,26 @@
+import boto3
 import io
+import threading
+
+
+class _Session:
+    """A threadsafe boto session.
+
+    Use the global module-level ``session`` instance of this class to get
+    a boto3 session.
+    """
+    def __init__(self):
+        self._session = threading.local()
+
+    def __call__(self):
+        try:
+            return self._session.s
+        except AttributeError:
+            self._session.s = boto3.session.Session()
+        return self._session.s
+
+
+session = _Session()
 
 
 class S3IO(io.RawIOBase):


### PR DESCRIPTION
This adds a singleton boto3 session class to deal with the fact that the
boto3 session isn't threadsafe. It's a little gross but given that boto3
is used throughout, just dumping it into a global thread local seems
like the least worst option.