### PR TITLE
Support publishing multiple layers at once

### DIFF
--- a/slingshot/__init__.py
+++ b/slingshot/__init__.py
@@ -6,3 +6,9 @@ Slingshot
 PUBLIC_WORKSPACE = "public"
 RESTRICTED_WORKSPACE = "secure"
 DATASTORE = "pg"
+
+
+class state:
+    PENDING = 0
+    FAILED = 1
+    PUBLISHED = 2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import os
 
 import boto3
-from moto import mock_s3
+from moto import mock_s3, mock_dynamodb2
 import pytest
 
 from slingshot.layer import Shapefile
@@ -14,6 +14,21 @@ def s3():
         conn.create_bucket(Bucket="upload")
         conn.create_bucket(Bucket="store")
         yield conn
+
+
+@pytest.fixture
+def dynamo_table():
+    with mock_dynamodb2():
+        db = boto3.resource('dynamodb')
+        table = db.create_table(
+            TableName="slingshot",
+            KeySchema=[{"AttributeName": "LayerName", "KeyType": "HASH"}],
+            AttributeDefinitions=[
+                {"AttributeName": "LayerName", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+            ProvisionedThroughput={"ReadCapacityUnits": 1,
+                                   "WriteCapacityUnits": 1})
+        yield table
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py37,unit,coverage,flake8,safety
 skipsdist = true
 
 [testenv]
-passenv = HOME PG_DATABASE AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID
+passenv = HOME PG_DATABASE AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID AWS_DEFAULT_REGION
 basepython = python3.7
 deps =
     pipenv
@@ -24,7 +24,7 @@ commands = pipenv run flake8 slingshot
 commands = pipenv check
 
 [testenv:coveralls]
-passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH PG_DATABASE AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH PG_DATABASE AWS_SECRET_ACCESS_KEY AWS_ACCESS_KEY_ID AWS_DEFAULT_REGION
 
 commands =
     pipenv install --dev


### PR DESCRIPTION
This changes the publish command to support publishing multiple layers
either by specifying the uploaded layer names as arguments or by using
the new `--publish-all` switch. If using the latter, this will scan the
upload bucket and publish all layers it finds. If a layer has already
been published it will be skipped if the published layer is newer than
the uploaded layer.

Rudimentary information about a layer's state is managed in a DynamoDB
table.