### PR TITLE
Make FGDC publicly available in S3

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,21 +16,6 @@ def runner():
     return CliRunner()
 
 
-@pytest.fixture
-def db():
-    uri = os.environ['PG_DATABASE']
-    schema = os.environ.get('PG_SCHEMA', 'public')
-    engine.configure(uri, schema)
-    if engine().has_table('bermuda', schema=schema):
-        with engine().connect() as conn:
-            conn.execute("DROP TABLE {}.bermuda".format(schema))
-    metadata().clear()
-    yield engine
-    if engine().has_table('bermuda', schema=schema):
-        with engine().connect() as conn:
-            conn.execute("DROP TABLE {}.bermuda".format(schema))
-
-
 @pytest.mark.integration
 def test_publishes_shapefile(db, runner, shapefile, s3, dynamo_table):
     bucket = s3.Bucket("upload")


### PR DESCRIPTION
The FGDC file for each layer should be made public, regardless of
whether or not the layer itself is restricted. This adds a step during
the publishing process to change the ACL to public read on the FGDC file
as well as adding the necessary link to the file in the GeoBlacklight
record.