### PR TITLE
Add OGC proxy URL

### DIFF
--- a/slingshot/app.py
+++ b/slingshot/app.py
@@ -226,10 +226,11 @@ class Solr(HttpMethodMixin):
         self.post('update', json={'commit': {}})
 
 
-def publish_layer(bucket, key, geoserver, solr, destination, s3_url=None):
+def publish_layer(bucket, key, geoserver, solr, destination, ogc_proxy,
+                  s3_url=None):
     unpacked = unpack_zip(bucket, key, destination, s3_url)
     layer = create_layer(*unpacked, s3_url)
-    layer.record = create_record(layer, geoserver.url)
+    layer.record = create_record(layer, ogc_proxy)
     layer.fgdc.obj.Acl().put(ACL="public-read")
     if layer.format == "Shapefile":
         load_layer(layer)

--- a/slingshot/cli.py
+++ b/slingshot/cli.py
@@ -104,6 +104,8 @@ def initialize(geoserver, geoserver_user, geoserver_password, db_host, db_port,
               help="Solr URL. Make sure to include the core name.")
 @click.option('--solr-user', envvar='SOLR_USER', help="Solr user")
 @click.option('--solr-password', envvar='SOLR_PASSWORD', help="Solr password")
+@click.option('--ogc-proxy', envvar='OGC_PROXY',
+              help="OGC proxy URL")
 @click.option('--s3-endpoint', envvar='S3_ENDPOINT',
               help="If using an alternative S3 service like Minio, set this "
                    "to the base URL for that service")
@@ -124,7 +126,7 @@ def publish(layers, db_uri, db_user, db_password, db_host, db_port, db_name,
             db_schema, geoserver, geoserver_user,
             geoserver_password, solr, solr_user, solr_password,
             s3_endpoint, s3_alias, dynamo_table, upload_bucket,
-            storage_bucket, num_workers, publish_all):
+            storage_bucket, num_workers, publish_all, ogc_proxy):
     if not any((layers, publish_all)) or all((layers, publish_all)):
         raise click.ClickException(
             "You must specify either one or more uploaded layer package names "
@@ -150,7 +152,8 @@ def publish(layers, db_uri, db_user, db_password, db_host, db_port, db_name,
     with ThreadPoolExecutor(max_workers=num_workers) as executor:
         futures = {executor.submit(publish_layer, upload_bucket, layer,
                                    geo_svc, solr_svc, storage_bucket,
-                                   s3_endpoint): layer for layer in work}
+                                   ogc_proxy, s3_endpoint):
+                   layer for layer in work}
         for future in as_completed(futures):
             layer = futures[future]
             try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,6 +39,7 @@ def test_publishes_shapefile(db, runner, shapefile, s3, dynamo_table):
                              '--geoserver', 'mock://example.com/geoserver/',
                              '--solr', 'mock://example.com/solr',
                              '--dynamo-table', dynamo_table.name,
+                             '--ogc-proxy', 'mock://example.com/ogc',
                              'bermuda.zip'])
     assert res.exit_code == 0
     assert "Published bermuda" in res.output
@@ -67,6 +68,7 @@ def test_publishes_geotiff(runner, geotiff, s3, dynamo_table):
                              '--geoserver', 'mock://example.com/geoserver/',
                              '--solr', 'mock://example.com/solr',
                              '--dynamo-table', dynamo_table.name,
+                             '--ogc-proxy', 'mock://example.com/ogc',
                              'france.zip'])
     assert res.exit_code == 0
     assert 'Published france' in res.output


### PR DESCRIPTION
The proxy URL for WMS/WFS needs to be written to the Geoblacklight
record instead of the URL for GeoServer.