### PR TITLE
Wait for ECS to flush logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY Pipfile* /
 RUN pipenv install --system --ignore-pipfile --deploy
 COPY --from=wheel /slingshot/dist/slingshot-*-py3-none-any.whl .
 RUN pip install slingshot-*-py3-none-any.whl
+COPY entrypoint.sh /
 
-ENTRYPOINT ["slingshot"]
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["--help"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+
+trap flush_logs EXIT
+
+flush_logs()
+{
+  code=$?
+  echo "slingshot exited with $code"
+  echo "Flushing ECS logs"
+  sleep 10
+  exit $code
+}
+
+slingshot "$@"

--- a/setup.py
+++ b/setup.py
@@ -35,13 +35,6 @@ setup(
         'requests',
     ],
     python_requires='>=3.7.1',
-    setup_requires=[
-        'pytest-runner',
-    ],
-    tests_require=[
-        'pytest',
-        'requests-mock',
-    ],
     entry_points={
         'console_scripts': [
             'slingshot = slingshot.cli:main',


### PR DESCRIPTION
It turns out ECS can frequently discard the logs before fully flushing
them to Cloudwatch. This was supposedly fixed recently but my experience
suggests otherwise. This adds a 10 second pause after slingshot has
exited before fully exiting the container. It seems to be enough to
ensure that all the slingshot logs are written to Cloudwatch.