### PR TITLE
 Use io.BufferedReader for Postgres COPY 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,7 @@ env:
     - TOX_ENV=flake8
     - TOX_ENV=safety
     - TOX_ENV=py37 AWS_SECRET_ACCESS_KEY=secret AWS_ACCESS_KEY_ID=key
-##
-# Coveralls appears to be broken. The test coverage is passing but it fails
-# when trying to submit the coverage.
-##
-#    - TOX_ENV=coveralls AWS_SECRET_ACCESS_KEY=secret AWS_ACCESS_KEY_ID=key
+    - TOX_ENV=coveralls AWS_SECRET_ACCESS_KEY=secret AWS_ACCESS_KEY_ID=key
 before_script:
     - psql -U postgres -c "CREATE DATABASE slingshot_test;"
     - psql -U postgres -d slingshot_test -c "CREATE EXTENSION postgis;"

--- a/slingshot/s3.py
+++ b/slingshot/s3.py
@@ -48,12 +48,25 @@ class S3IO(io.RawIOBase):
             self._position += offset
         else:
             self._position = self.obj.content_length + offset
+        return self._position
 
     def readable(self):
         return True
 
+    def writable(self):
+        return False
+
     def seekable(self):
         return True
+
+    def readall(self):
+        return self.read()
+
+    def readinto(self, b):
+        data = self.read(len(b))
+        n = len(data)
+        b[:n] = data
+        return n
 
     def read(self, size=-1):
         if size == 0 or self.tell() >= self.obj.content_length:


### PR DESCRIPTION
This fixes a few problems with the S3IO wrapper. These changes make it
possible to use the `io.BufferedReader` for the different files in the
Shapefile when loading into Postgres. Memory usage should now be fully
capped and largely controlled by the number of worker threads and size
of the `S3_BUFFER_SIZE` constant.