### PR TITLE
Exit if parsing fails

### DIFF
--- a/slingshot/marc.py
+++ b/slingshot/marc.py
@@ -89,10 +89,8 @@ class MarcParser(Iterator):
         while True:
             try:
                 record = next(self.reader)
-            except StopIteration:
-                raise
-            except Exception:
-                # pymarc does not handle broken marc at all
+            except UnicodeDecodeError:
+                # skip records that can't be parsed
                 continue
             if not record:
                 continue

--- a/slingshot/record.py
+++ b/slingshot/record.py
@@ -63,7 +63,7 @@ def envelope_validator(instance, attribute, value):
     if not m:
         raise ValueError('Invalid envelope string')
     d = {k: Decimal(v) for k, v in m.groupdict().items()}
-    if not (d['N'] > d['S'] and d['E'] > d['W']):
+    if not (d['N'] >= d['S'] and d['E'] >= d['W']):
         raise ValueError('Invalid envelope string')
     if not (-180 <= d['E'] <= 180 and -180 <= d['W'] <= 180 and
             -90 <= d['N'] <= 90 and -90 <= d['S'] <= 90):


### PR DESCRIPTION
This fixes a bug that caused the process to endlessly loop, making
failed requests to S3. The MARC parser will now raise an exception for
anything except for an encoding problem.

It also changes the bounding box validator to allow points.