### PR TITLE
Alma updates

### DIFF
--- a/slingshot/cli.py
+++ b/slingshot/cli.py
@@ -211,15 +211,27 @@ def reindex(bucket, solr, solr_user, solr_password):
               help='Username for Solr.')
 @click.option('--solr-password', envvar='SOLR_PASSWORD',
               help='Password for Solr.')
-def marc(marc_file, solr, solr_user, solr_password):
+@click.option('--s3-endpoint', envvar='S3_ENDPOINT',
+              help="If using an alternative S3 service like Minio, set this "
+                   "to the base URL for that service")
+@click.option('--s3-alias', envvar='S3_ALIAS', default='s3',
+              help="The GeoServer S3 plugin requires a different alias (which "
+                   "appears as the protocol) for alternative S3 services, for "
+                   "example: minio://bucket/key. See https://docs.geoserver.org/latest/en/user/community/s3-geotiff/index.html "  # noqa: E501
+                   "for more information.")
+@click.option('--aws-region', envvar='AWS_DEFAULT_REGION', default='us-east-1',
+              help="AWS region")
+def marc(marc_file, solr, solr_user, solr_password, s3_endpoint, s3_alias,
+         aws_region):
     """Index MARC records into Solr.
 
     This will delete existing MIT records with a dc_format_s of
     "Paper Map" or "Cartographic Material", and then index all appropriate
-    records from the provided MARC XML file.
+    records from the provided MARC file.
     """
     fparts = urlparse(marc_file)
-    s3 = session().resource('s3', region_name='us-east-1')
+    s3 = session().resource("s3", endpoint_url=s3_endpoint,
+                            region_name=aws_region)
     marc = io.BufferedReader(
                 S3IO(s3.Object(fparts.netloc, fparts.path.lstrip('/'))),
                 buffer_size=S3_BUFFER_SIZE)

--- a/slingshot/marc.py
+++ b/slingshot/marc.py
@@ -98,7 +98,9 @@ class MarcParser(Iterator):
                 continue
             if not record:
                 continue
-            ident = f'http://library.mit.edu/item/{record["001"].value()}'
+            ident = (f'https://mit.primo.exlibrisgroup.com/discovery/'
+                     f'fulldisplay?vid=01MIT_INST:MIT&docid=alma'
+                     f'{record["001"].value()}')
             subjects = {sf for f in record.get_fields('650')
                         for sf in f.get_subfields('a')}
             spatial_subjects = {sf for f in record.get_fields('650')

--- a/slingshot/marc.py
+++ b/slingshot/marc.py
@@ -3,6 +3,7 @@ from decimal import Decimal, getcontext
 import re
 
 from pymarc import Record
+from pymarc.exceptions import RecordDirectoryInvalid
 
 from slingshot.app import make_slug
 
@@ -63,7 +64,7 @@ class BadMARCReader(Iterator):
         while True:
             idx = self.__buffer.find(RECORD_TERMINATOR)
             if idx >= 0:
-                chunk = self.__buffer[:idx]
+                chunk = self.__buffer[:idx+1]
                 self.__buffer = self.__buffer[idx+1:]
                 # In case the buffer starts with a record terminator, keep
                 # trying until we have a record or reach the end.
@@ -91,6 +92,9 @@ class MarcParser(Iterator):
                 record = next(self.reader)
             except UnicodeDecodeError:
                 # skip records that can't be parsed
+                continue
+            except RecordDirectoryInvalid:
+                print('Record directory invalid, skipping record')
                 continue
             if not record:
                 continue

--- a/tests/test_marc.py
+++ b/tests/test_marc.py
@@ -12,21 +12,25 @@ def single_record():
 def test_parser_returns_record_dictionary(single_record):
     parser = MarcParser(single_record)
     record = dict(
-        dc_identifier_s='http://library.mit.edu/item/002107286',
+        dc_identifier_s=('https://mit.primo.exlibrisgroup.com/discovery/'
+                         'fulldisplay?vid=01MIT_INST:MIT&docid=alma002107286'),
         dc_rights_s='Public',
         dc_title_s='Afghanistan country profile : '
                    'Afghanistan provinces and districts.',
         dc_publisher_s='[Central Intelligence Agency],',
         dc_creator_sm=['United States. Central Intelligence Agency.'],
         dc_type_s='Physical Object',
-        dct_references_s={'http://schema.org/url':
-                          'http://library.mit.edu/item/002107286'},
+        dct_references_s={
+            'http://schema.org/url':
+            ('https://mit.primo.exlibrisgroup.com/discovery/'
+             'fulldisplay?vid=01MIT_INST:MIT&docid=alma002107286')
+        },
         layer_geom_type_s='Mixed',
         dc_subject_sm={'Geography', 'Area studies', 'Demography'},
         dct_spatial_sm={'Afghanistan'},
         dct_temporal_sm='[2012]',
         solr_geom='ENVELOPE(60, 74.5, 38.5, 29)',
         dc_format_s='Paper Map',
-        layer_slug_s='mit-epowtnzw5fkdo',
+        layer_slug_s='mit-thh43bskinod2',
     )
     assert next(parser) == record


### PR DESCRIPTION
#### What does this PR do
Updates the MARC parser to correctly parse and ingest Alma records into Geoweb. This includes:
- Fixing a record parsing bug in the MARC parser that was presumably there to handle poorly structured MARC records from Aleph
- Updating the source record URL to point to Primo for Alma records
- Updating the CLI `marc` command to enable local testing against the Geoweb dev environment
- Updating tests

#### How to see these changes
So...this is not simple. However, it is possible. The [geoweb repository](https://github.com/mitlibraries/geoweb) has instructions for setting up a local Geoweb dev environment using docker-compose. You can do that (following all the instructions carefully), upload an Alma record export (see dip-stage s3 bucket) to the local Minio upload folder, and then run the slingshot command `pipenv run slingshot marc s3://upload/<filename.mrc>`. After the process finishes you should see records in your local Geoweb instance at `localhost:3000`. 

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies

NO
