### PR TITLE
Fix bug in MARC parser, update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,12 @@ update: ## Update all Python dependencies
 	pipenv update --dev
 
 publish: ## Push and tag the latest image (use `make dist && make publish`)
-	$$(aws ecr get-login --no-include-email --region us-east-1)
+	aws ecr get-login-password | docker login 	--password-stdin --username AWS $(ECR_REGISTRY)
 	docker push $(ECR_REGISTRY)/slingshot-stage:latest
 	docker push $(ECR_REGISTRY)/slingshot-stage:`git describe --always`
 
 promote: ## Promote the current staging build to production
-	$$(aws ecr get-login --no-include-email --region us-east-1)
+	aws ecr get-login-password | docker login 	--password-stdin --username AWS $(ECR_REGISTRY)
 	docker pull $(ECR_REGISTRY)/slingshot-stage:latest
 	docker tag $(ECR_REGISTRY)/slingshot-stage:latest $(ECR_REGISTRY)/slingshot-prod:latest
 	docker tag $(ECR_REGISTRY)/slingshot-stage:latest $(ECR_REGISTRY)/slingshot-prod:$(DATETIME)

--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,12 @@ update: ## Update all Python dependencies
 	pipenv update --dev
 
 publish: ## Push and tag the latest image (use `make dist && make publish`)
-	aws ecr get-login-password | docker login 	--password-stdin --username AWS $(ECR_REGISTRY)
+	aws ecr get-login-password | docker login --password-stdin --username AWS $(ECR_REGISTRY)
 	docker push $(ECR_REGISTRY)/slingshot-stage:latest
 	docker push $(ECR_REGISTRY)/slingshot-stage:`git describe --always`
 
 promote: ## Promote the current staging build to production
-	aws ecr get-login-password | docker login 	--password-stdin --username AWS $(ECR_REGISTRY)
+	aws ecr get-login-password | docker login --password-stdin --username AWS $(ECR_REGISTRY)
 	docker pull $(ECR_REGISTRY)/slingshot-stage:latest
 	docker tag $(ECR_REGISTRY)/slingshot-stage:latest $(ECR_REGISTRY)/slingshot-prod:latest
 	docker tag $(ECR_REGISTRY)/slingshot-stage:latest $(ECR_REGISTRY)/slingshot-prod:$(DATETIME)

--- a/slingshot/marc.py
+++ b/slingshot/marc.py
@@ -119,6 +119,10 @@ class MarcParser(Iterator):
                 geom = f'ENVELOPE({w}, {e}, {n}, {s})'
             else:
                 geom = None
+            pubyear = record.pubyear()
+            if pubyear is not None:
+                pubyear = pubyear.replace("[", "").replace("]", "").replace(
+                    "c", "").replace(".", "").replace("?", "").replace(" ", "")
             r = dict(
                 dc_identifier_s=ident,
                 dc_rights_s='Public',
@@ -130,7 +134,7 @@ class MarcParser(Iterator):
                 layer_geom_type_s='Mixed',
                 dc_subject_sm=subjects,
                 dct_spatial_sm=spatial_subjects,
-                dct_temporal_sm=record.pubyear(),
+                dct_temporal_sm=pubyear,
                 solr_geom=geom,
                 dc_format_s=fmt,
                 layer_slug_s=make_slug(ident),

--- a/slingshot/record.py
+++ b/slingshot/record.py
@@ -121,7 +121,7 @@ class Record:
     dct_issued_dt = Field()
     dct_provenance_s = Field(default='MIT')
     dct_spatial_sm = Field(converter=_set)
-    dct_temporal_sm = Field(converter=_set)
+    dct_temporal_sm = Field()
     dct_references_s = Field(validator=validators.optional(
                                 validators.instance_of(dict)))
     layer_geom_type_s = Field(validator=one_of(GEOMS),

--- a/tests/test_marc.py
+++ b/tests/test_marc.py
@@ -28,7 +28,7 @@ def test_parser_returns_record_dictionary(single_record):
         layer_geom_type_s='Mixed',
         dc_subject_sm={'Geography', 'Area studies', 'Demography'},
         dct_spatial_sm={'Afghanistan'},
-        dct_temporal_sm='[2012]',
+        dct_temporal_sm='2012',
         solr_geom='ENVELOPE(60, 74.5, 38.5, 29)',
         dc_format_s='Paper Map',
         layer_slug_s='mit-thh43bskinod2',


### PR DESCRIPTION
#### Why these changes are being introduced:
The record publication date field was processed into JSON as an array instead of a string, which resulted in very strange dates in the Geoblacklight view. The dates also include some odd characters that are correct for MARC cataloging but that we don't want to display.

#### How this addresses that need:
* Changs the record date field (dct_temporal_sm) to a string instead of an array
* Strips brackets and other cataloging characters
  year string before ingesting
* Also updates the Makefile to use new AWS CLI login command

#### Side effects of this change:
None, but Slingshot will need to be re-run after merge with the latest full export from Alma.